### PR TITLE
feat: user script managed deployment

### DIFF
--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -53,6 +53,16 @@ resource "aws_launch_template" "fastapi_app" {
     enabled = true
   }
 
+  # EBS block device configuration
+  block_device_mappings {
+    device_name = "/dev/sda1"
+    ebs {
+      volume_size           = 60
+      volume_type           = "gp3"
+      delete_on_termination = true
+    }
+  }
+
   # Enable instance metadata service
   metadata_options {
     http_endpoint               = "enabled"
@@ -70,7 +80,14 @@ resource "aws_launch_template" "fastapi_app" {
         systemctl enable amazon-ssm-agent
         systemctl start amazon-ssm-agent
         
-        # TODO: Figure out a better solution for deploying FTW app
+        # Deploy FTW inference API as ubuntu user
+        sudo -u ubuntu bash -c "cd /home/ubuntu && curl -L https://raw.githubusercontent.com/fieldsoftheworld/ftw-inference-api/main/deploy.sh | bash"
+        
+        # Configure API for auth-disabled mode
+        sudo -u ubuntu sed -i 's/auth_disabled: false/auth_disabled: true/' /home/ubuntu/ftw-inference-api/server/config/config.yaml
+        
+        # Restart the FTW inference API service
+        systemctl restart ftw-inference-api
     EOF
   )
 


### PR DESCRIPTION
Basic change to the ec2 launch template and EBS block size.

- The new user script picks up the latest version of the ftw-inference-api deploy script and executes it. This allows the instances to come up and down according to the auto scaling policy.
- When using Conda for the dependency manager in ftw-inference-api we have to increase the EBS size. It requires much more space than the original UV version.

- [x] Test and active in AWS