### PR TITLE
Implement DynamoDB integration for stateless architecture

### DIFF
--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -76,9 +76,10 @@ module "iam" {
   source = "../../modules/iam"
 
   # Required variables
-  environment   = var.environment
-  region        = var.region
-  s3_bucket_arn = module.s3.output_bucket_arn
+  environment        = var.environment
+  region             = var.region
+  s3_bucket_arn      = module.s3.output_bucket_arn
+  dynamodb_table_arn = module.dynamodb.dynamodb_table_arn
 }
 
 module "api_gateway" {
@@ -126,9 +127,10 @@ resource "aws_route53_record" "api_custom_domain" {
 module "security_groups" {
   source = "../../modules/security-groups"
 
-  environment    = var.environment
-  vpc_id         = module.vpc.vpc_id
-  vpc_cidr_block = module.vpc.vpc_cidr_block
+  environment             = var.environment
+  vpc_id                  = module.vpc.vpc_id
+  vpc_cidr_block          = module.vpc.vpc_cidr_block
+  enable_vpc_endpoints_sg = true
 }
 
 module "alb" {
@@ -139,7 +141,7 @@ module "alb" {
   vpc_id                 = module.vpc.vpc_id
   private_subnet_ids     = module.vpc.private_subnet_ids
   alb_security_group_ids = [module.security_groups.alb_security_group_id]
-  certificate_arn        = ""
+
 
   alb_config = {
     health_check_interval = 300
@@ -197,3 +199,17 @@ module "cloudfront" {
   depends_on = [module.waf, module.api_gateway, module.certificate_manager]
 }
 
+# DynamoDB Module - Project state management
+module "dynamodb" {
+  source = "../../modules/dynamodb"
+
+  environment                     = var.environment
+  vpc_id                          = module.vpc.vpc_id
+  private_subnet_ids              = module.vpc.private_subnet_ids
+  vpc_endpoint_security_group_ids = [module.security_groups.vpc_endpoints_security_group_id]
+
+  tags = {
+    Environment = var.environment
+    Project     = "fields-of-the-world"
+  }
+}

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -189,3 +189,7 @@ variable "custom_domain_name" {
   type        = string
   default     = ""
 }
+variable "dynamodb_table_arn" {
+  description = "DynamoDB table ARN for EC2 access"
+  type        = string
+}

--- a/modules/dynamodb/main.tf
+++ b/modules/dynamodb/main.tf
@@ -1,0 +1,94 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+# DYNAMODB TABLE FOR PROJECT MANAGEMENT
+
+resource "aws_dynamodb_table" "ftw_inference_api_table" {
+  name           = "${var.environment}-ftw-inference-api-table"
+  billing_mode   = "PROVISIONED"
+  read_capacity  = var.read_capacity
+  write_capacity = var.write_capacity
+  hash_key       = "project_id"
+
+  attribute {
+    name = "project_id"
+    type = "S"
+  }
+
+  # Enable point-in-time recovery
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  # Server-side encryption
+  server_side_encryption {
+    enabled = true
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name        = "${var.environment}-ftw-inference-api-table"
+      Environment = var.environment
+      Purpose     = "project-state-management"
+    }
+  )
+}
+
+# VPC ENDPOINT FOR DYNAMODB ACCESS
+
+resource "aws_vpc_endpoint" "dynamodb" {
+  vpc_id              = var.vpc_id
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.dynamodb"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = var.private_subnet_ids
+  security_group_ids  = var.vpc_endpoint_security_group_ids
+  
+  # Enable private DNS resolution
+  private_dns_enabled = true
+  
+  # Policy to allow access to our specific table
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = "*"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:PutItem",
+          "dynamodb:UpdateItem",
+          "dynamodb:DeleteItem",
+          "dynamodb:Query",
+          "dynamodb:Scan",
+          "dynamodb:DescribeTable"
+        ]
+        Resource = [
+  aws_dynamodb_table.ftw_inference_api_table.arn,          
+  "${aws_dynamodb_table.ftw_inference_api_table.arn}/*"     
+]
+      }
+    ]
+  })
+
+  tags = merge(
+    var.tags,
+    {
+      Name        = "${var.environment}-dynamodb-vpc-endpoint"
+      Environment = var.environment
+      Purpose     = "private-dynamodb-access"
+    }
+  )
+}
+
+# DATA SOURCES
+
+
+data "aws_region" "current" {}
+

--- a/modules/dynamodb/outputs.tf
+++ b/modules/dynamodb/outputs.tf
@@ -1,0 +1,24 @@
+output "dynamodb_table_name" {
+  description = "Name of the DynamoDB table"
+  value       = aws_dynamodb_table.ftw_inference_api_table.name 
+}
+
+output "dynamodb_table_arn" {
+  description = "ARN of the DynamoDB table"
+  value       = aws_dynamodb_table.ftw_inference_api_table.arn
+}
+
+output "dynamodb_table_id" {
+  description = "ID of the DynamoDB table"
+  value       = aws_dynamodb_table.ftw_inference_api_table.id
+}
+
+output "vpc_endpoint_id" {
+  description = "ID of the DynamoDB VPC endpoint"
+  value       = aws_vpc_endpoint.dynamodb.id
+}
+
+output "vpc_endpoint_dns_names" {
+  description = "DNS names of the DynamoDB VPC endpoint"
+  value       = aws_vpc_endpoint.dynamodb.dns_entry[*].dns_name
+}

--- a/modules/dynamodb/variables.tf
+++ b/modules/dynamodb/variables.tf
@@ -1,0 +1,37 @@
+variable "environment" {
+  description = "Environment name (dev, staging, prod)"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID where DynamoDB VPC endpoint will be created"
+  type        = string
+}
+
+variable "private_subnet_ids" {
+  description = "List of private subnet IDs for VPC endpoint"
+  type        = list(string)
+}
+
+variable "vpc_endpoint_security_group_ids" {
+  description = "Security group IDs for VPC endpoint"
+  type        = list(string)
+}
+
+variable "read_capacity" {
+  description = "Read capacity units for DynamoDB table"
+  type        = number
+  default     = 5
+}
+
+variable "write_capacity" {
+  description = "Write capacity units for DynamoDB table"
+  type        = number
+  default     = 5
+}
+
+variable "tags" {
+  description = "Tags to apply to DynamoDB resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -49,7 +49,7 @@ resource "aws_iam_instance_profile" "ec2_fastapi_app_profile" {
   }
 }
 
-# Cloudwatch and logging policy foir EC2
+# Cloudwatch and logging policy for EC2
 resource "aws_iam_role_policy" "ec2_cloudwatch_policy" {
   name = "${var.environment}-ec2-cloudwatch-policy"
   role = aws_iam_role.ec2_fastapi_app_role.id
@@ -109,6 +109,34 @@ resource "aws_iam_role_policy" "ec2_s3_policy" {
           "s3:GetBucketLocation"
         ]
         Resource = "*"
+      }
+    ]
+  })
+}
+
+# DynamoDB access policy for EC2
+resource "aws_iam_role_policy" "ec2_dynamodb_policy" {
+  name = "${var.environment}-ec2-dynamodb-policy"
+  role = aws_iam_role.ec2_fastapi_app_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:PutItem", 
+          "dynamodb:UpdateItem",
+          "dynamodb:DeleteItem",
+          "dynamodb:Query",
+          "dynamodb:Scan",
+          "dynamodb:DescribeTable"
+        ]
+        Resource = [
+          var.dynamodb_table_arn,
+          "${var.dynamodb_table_arn}/*"
+        ]
       }
     ]
   })

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -24,3 +24,8 @@ variable "enable_alb_oidc_auth" {
   type        = bool
   default     = false
 }
+
+variable "dynamodb_table_arn" {
+  description = "DynamoDB table ARN for EC2 access"
+  type        = string
+}


### PR DESCRIPTION
- Created DynamoDB table: dev-ftw-inference-api-table with project_id partition key
- VPC Interface endpoint for private subnet access only
- Added IAM permissions for EC2 instances to access DynamoDB
- Integrated modules into dev environment configuration


Closes #17