### PR TITLE
fix: v1 routes, dynamodb errors, and formatting

### DIFF
--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -186,7 +186,7 @@ module "cloudfront" {
   source = "../../modules/cloudfront"
 
   environment            = var.environment
-  api_gateway_invoke_url = module.api_gateway.stage_invoke_url
+  api_gateway_invoke_url = module.api_gateway.api_endpoint
   waf_web_acl_arn        = module.waf.web_acl_arn
   custom_domain_name     = var.custom_domain_name
   certificate_arn        = module.certificate_manager.cloudfront_certificate_arn
@@ -206,6 +206,10 @@ module "dynamodb" {
   vpc_id                          = module.vpc.vpc_id
   private_subnet_ids              = module.vpc.private_subnet_ids
   vpc_endpoint_security_group_ids = [module.security_groups.vpc_endpoints_security_group_id]
+  route_table_ids = concat(
+    [module.vpc.public_route_table_id],
+    module.vpc.private_route_table_ids
+  )
 
   tags = {
     Environment = var.environment

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -189,7 +189,3 @@ variable "custom_domain_name" {
   type        = string
   default     = ""
 }
-variable "dynamodb_table_arn" {
-  description = "DynamoDB table ARN for EC2 access"
-  type        = string
-}

--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -50,7 +50,7 @@ resource "aws_lb_target_group" "fastapi" {
     unhealthy_threshold = var.alb_config.health_check_unhealthy_threshold
     timeout             = var.alb_config.health_check_timeout
     interval            = var.alb_config.health_check_interval
-    path                = var.health_check_path
+    path                = "/v1${var.health_check_path}"
     matcher             = var.alb_config.health_check_matcher
     port                = "traffic-port"
     protocol            = "HTTP"

--- a/modules/api-gateway/routes.tf
+++ b/modules/api-gateway/routes.tf
@@ -15,9 +15,9 @@ resource "aws_apigatewayv2_integration" "alb_integration" {
   # Timeout settings (max 30 seconds for API Gateway)
   timeout_milliseconds = 29000
 
-  # Request transformation - pass the original path to ALB
+  # Request transformation - prepend stage name to all paths for FastAPI
   request_parameters = {
-    "overwrite:path" = "$request.path"
+    "overwrite:path" = "/${var.stage_name}$request.path"
   }
 }
 # API GATEWAY ROUTES

--- a/modules/cloudfront/main.tf
+++ b/modules/cloudfront/main.tf
@@ -38,7 +38,6 @@ resource "aws_cloudfront_distribution" "api_distribution" {
   origin {
     domain_name = regex("https://([^/]+)", var.api_gateway_invoke_url)[0]
     origin_id   = "api-gateway-${var.environment}"
-    origin_path = "/v1"
 
     custom_origin_config {
       http_port              = 80

--- a/modules/dynamodb/main.tf
+++ b/modules/dynamodb/main.tf
@@ -44,21 +44,17 @@ resource "aws_dynamodb_table" "ftw_inference_api_table" {
 # VPC ENDPOINT FOR DYNAMODB ACCESS
 
 resource "aws_vpc_endpoint" "dynamodb" {
-  vpc_id              = var.vpc_id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.dynamodb"
-  vpc_endpoint_type   = "Interface"
-  subnet_ids          = var.private_subnet_ids
-  security_group_ids  = var.vpc_endpoint_security_group_ids
-  
-  # Enable private DNS resolution
-  private_dns_enabled = true
-  
+  vpc_id            = var.vpc_id
+  service_name      = "com.amazonaws.${data.aws_region.current.name}.dynamodb"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = var.route_table_ids
+
   # Policy to allow access to our specific table
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {
-        Effect = "Allow"
+        Effect    = "Allow"
         Principal = "*"
         Action = [
           "dynamodb:GetItem",
@@ -70,9 +66,9 @@ resource "aws_vpc_endpoint" "dynamodb" {
           "dynamodb:DescribeTable"
         ]
         Resource = [
-  aws_dynamodb_table.ftw_inference_api_table.arn,          
-  "${aws_dynamodb_table.ftw_inference_api_table.arn}/*"     
-]
+          aws_dynamodb_table.ftw_inference_api_table.arn,
+          "${aws_dynamodb_table.ftw_inference_api_table.arn}/*"
+        ]
       }
     ]
   })

--- a/modules/dynamodb/outputs.tf
+++ b/modules/dynamodb/outputs.tf
@@ -1,6 +1,6 @@
 output "dynamodb_table_name" {
   description = "Name of the DynamoDB table"
-  value       = aws_dynamodb_table.ftw_inference_api_table.name 
+  value       = aws_dynamodb_table.ftw_inference_api_table.name
 }
 
 output "dynamodb_table_arn" {

--- a/modules/dynamodb/variables.tf
+++ b/modules/dynamodb/variables.tf
@@ -35,3 +35,8 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "route_table_ids" {
+  description = "List of route table IDs for DynamoDB Gateway VPC endpoint"
+  type        = list(string)
+}

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -126,7 +126,7 @@ resource "aws_iam_role_policy" "ec2_dynamodb_policy" {
         Effect = "Allow"
         Action = [
           "dynamodb:GetItem",
-          "dynamodb:PutItem", 
+          "dynamodb:PutItem",
           "dynamodb:UpdateItem",
           "dynamodb:DeleteItem",
           "dynamodb:Query",

--- a/modules/iam/outputs.tf
+++ b/modules/iam/outputs.tf
@@ -34,8 +34,8 @@ output "api_gateway_role_name" {
 output "policies_attached" {
   description = "List of policies and features enabled for the EC2 role"
   value = {
-    cloudwatch_logs        = true
-    s3_access             = true
+    cloudwatch_logs = true
+    s3_access       = true
   }
 }
 

--- a/modules/waf/main.tf
+++ b/modules/waf/main.tf
@@ -2,8 +2,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      version = "~> 5.0"
+      source                = "hashicorp/aws"
+      version               = "~> 5.0"
       configuration_aliases = [aws]
     }
   }
@@ -35,8 +35,8 @@ resource "aws_wafv2_web_acl" "main" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                 = "${var.environment}-CommonRuleSetMetric"
-      sampled_requests_enabled    = true
+      metric_name                = "${var.environment}-CommonRuleSetMetric"
+      sampled_requests_enabled   = true
     }
   }
 
@@ -58,8 +58,8 @@ resource "aws_wafv2_web_acl" "main" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                 = "${var.environment}-KnownBadInputsMetric"
-      sampled_requests_enabled    = true
+      metric_name                = "${var.environment}-KnownBadInputsMetric"
+      sampled_requests_enabled   = true
     }
   }
 
@@ -81,8 +81,8 @@ resource "aws_wafv2_web_acl" "main" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                 = "${var.environment}-RateLimitMetric"
-      sampled_requests_enabled    = true
+      metric_name                = "${var.environment}-RateLimitMetric"
+      sampled_requests_enabled   = true
     }
   }
 
@@ -104,8 +104,8 @@ resource "aws_wafv2_web_acl" "main" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                 = "${var.environment}-IpReputationMetric"
-      sampled_requests_enabled    = true
+      metric_name                = "${var.environment}-IpReputationMetric"
+      sampled_requests_enabled   = true
     }
   }
 
@@ -127,15 +127,15 @@ resource "aws_wafv2_web_acl" "main" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                 = "${var.environment}-AnonymousIpMetric"
-      sampled_requests_enabled    = true
+      metric_name                = "${var.environment}-AnonymousIpMetric"
+      sampled_requests_enabled   = true
     }
   }
 
   visibility_config {
     cloudwatch_metrics_enabled = true
-    metric_name                 = "${var.environment}-WebACL"
-    sampled_requests_enabled    = true
+    metric_name                = "${var.environment}-WebACL"
+    sampled_requests_enabled   = true
   }
 
   tags = merge(


### PR DESCRIPTION
Refactoring of the API required us to update the API Gateway routes and Cloudfront configuration. We now have a standard /v1/ versioning path defined both in the API code and in the API Gateway routes. This design will allow use to keep old API versions available should we need to do a major rework at some point. Zach is aware of the changes and is updating the URL environment variable used by the web app.

I also fixed some formatting issues and a small issue related to the DynamoDB table.