### PR TITLE
Implement SQS task queue to replace asyncio.Queue

### DIFF
--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -80,6 +80,7 @@ module "iam" {
   region             = var.region
   s3_bucket_arn      = module.s3.output_bucket_arn
   dynamodb_table_arn = module.dynamodb.dynamodb_table_arn
+  sqs_queue_arn      = module.sqs.task_queue_arn
 }
 
 module "api_gateway" {
@@ -211,6 +212,17 @@ module "dynamodb" {
     module.vpc.private_route_table_ids
   )
 
+  tags = {
+    Environment = var.environment
+    Project     = "fields-of-the-world"
+  }
+}
+# SQS Module - Task queue to replace asyncio.Queue
+module "sqs" {
+  source = "../../modules/sqs"
+  
+  environment = var.environment
+  
   tags = {
     Environment = var.environment
     Project     = "fields-of-the-world"

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -191,3 +191,30 @@ resource "aws_iam_role_policy" "api_gateway_cloudwatch_policy" {
     ]
   })
 }
+
+# SQS access policy for EC2 (only create if SQS ARN is provided)
+resource "aws_iam_role_policy" "ec2_sqs_policy" {
+  
+  name = "${var.environment}-ec2-sqs-policy"
+  role = aws_iam_role.ec2_fastapi_app_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:SendMessage",
+          "sqs:GetQueueAttributes",
+          "sqs:ChangeMessageVisibility"
+        ]
+        Resource = [
+          var.sqs_queue_arn,
+          "${replace(var.sqs_queue_arn, ":task-queue", ":task-dlq")}"
+        ]
+      }
+    ]
+  })
+}

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -29,3 +29,7 @@ variable "dynamodb_table_arn" {
   description = "DynamoDB table ARN for EC2 access"
   type        = string
 }
+variable "sqs_queue_arn" {
+  description = "SQS queue ARN for EC2 access"
+  type        = string
+}

--- a/modules/sqs/main.tf
+++ b/modules/sqs/main.tf
@@ -1,0 +1,83 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+# Dead Letter Queue for failed tasks
+resource "aws_sqs_queue" "task_dlq" {
+  name = "${var.environment}-ftw-task-dlq"
+
+  message_retention_seconds = var.message_retention_period
+
+  tags = merge(
+    var.tags,
+    {
+      Name        = "${var.environment}-ftw-task-dlq"
+      Environment = var.environment
+      Purpose     = "failed-task-storage"
+    }
+  )
+}
+
+# Main task queue (replaces asyncio.Queue)
+resource "aws_sqs_queue" "task_queue" {
+  name = "${var.environment}-ftw-task-queue"
+
+  # Message settings for ML tasks
+  visibility_timeout_seconds = var.visibility_timeout
+  message_retention_seconds  = var.message_retention_period
+  
+  # Long polling for efficiency
+  receive_wait_time_seconds = 20
+
+  # Dead letter queue configuration
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.task_dlq.arn
+    maxReceiveCount     = var.max_receive_count
+  })
+
+  tags = merge(
+    var.tags,
+    {
+      Name        = "${var.environment}-ftw-task-queue"
+      Environment = var.environment
+      Purpose     = "inference-polygonize-tasks"
+    }
+  )
+}
+
+# Queue policy to allow EC2 instances to access
+resource "aws_sqs_queue_policy" "task_queue_policy" {
+  queue_url = aws_sqs_queue.task_queue.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = "*"
+        }
+        Action = [
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:SendMessage",
+          "sqs:GetQueueAttributes"
+        ]
+        Resource = aws_sqs_queue.task_queue.arn
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      }
+    ]
+  })
+}
+
+# Data source for account ID
+data "aws_caller_identity" "current" {}

--- a/modules/sqs/output.tf
+++ b/modules/sqs/output.tf
@@ -1,0 +1,24 @@
+output "task_queue_url" {
+  description = "SQS task queue URL for EC2 workers"
+  value       = aws_sqs_queue.task_queue.url
+}
+
+output "task_queue_arn" {
+  description = "SQS task queue ARN"
+  value       = aws_sqs_queue.task_queue.arn
+}
+
+output "task_queue_name" {
+  description = "SQS task queue name"
+  value       = aws_sqs_queue.task_queue.name
+}
+
+output "dlq_url" {
+  description = "Dead letter queue URL"
+  value       = aws_sqs_queue.task_dlq.url
+}
+
+output "dlq_arn" {
+  description = "Dead letter queue ARN"
+  value       = aws_sqs_queue.task_dlq.arn
+}

--- a/modules/sqs/variables.tf
+++ b/modules/sqs/variables.tf
@@ -1,0 +1,28 @@
+variable "environment" {
+  description = "Environment name (dev, staging, prod)"
+  type        = string
+}
+
+variable "visibility_timeout" {
+  description = "Message visibility timeout in seconds (for long-running ML tasks)"
+  type        = number
+  default     = 900  # 15 minutes for inference/polygonize tasks
+}
+
+variable "message_retention_period" {
+  description = "How long to keep messages in queue (seconds)"
+  type        = number
+  default     = 1209600  # 14 days
+}
+
+variable "max_receive_count" {
+  description = "Max times a message can be received before moving to DLQ"
+  type        = number
+  default     = 3
+}
+
+variable "tags" {
+  description = "Tags to apply to SQS resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
- Created SQS task queue: dev-ftw-task-queue for inference/polygonize tasks
- Created dead letter queue: dev-ftw-task-dlq for failed task handling
- Added IAM permissions for EC2 instances to access SQS queues
- Configured 15-minute visibility timeout for long-running ML tasks
- Long polling enabled for efficiency and cost optimization
- Terraform validates and plans successfully

Addresses horizontal scaling requirement by replacing local asyncio.Queue with distributed SQS that multiple EC2 instances can access as workers.