### PR TITLE
chg: new three table dynamodb config

### DIFF
--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -103,12 +103,14 @@ module "iam" {
   source = "../../modules/iam"
 
   # Required variables
-  environment        = var.environment
-  region             = var.region
-  s3_bucket_arn      = module.s3.output_bucket_arn
-  dynamodb_table_arn = module.dynamodb.dynamodb_table_arn
-  sqs_queue_arn      = module.sqs.task_queue_arn
-  sqs_dlq_arn        = module.sqs.dlq_arn
+  environment                 = var.environment
+  region                      = var.region
+  s3_bucket_arn               = module.s3.output_bucket_arn
+  projects_table_arn          = module.dynamodb.projects_table_arn
+  images_table_arn            = module.dynamodb.images_table_arn
+  inference_results_table_arn = module.dynamodb.inference_results_table_arn
+  sqs_queue_arn               = module.sqs.task_queue_arn
+  sqs_dlq_arn                 = module.sqs.dlq_arn
 
 }
 
@@ -137,7 +139,7 @@ module "api_gateway" {
   enable_cloudfront_protection    = true
   lambda_authorizer_invoke_arn    = module.lambda_authorizer.authorizer_invoke_arn
   lambda_authorizer_function_name = module.lambda_authorizer.authorizer_function_name
-  depends_on = [module.certificate_manager]
+  depends_on                      = [module.certificate_manager]
 }
 
 # Route53 record for custom domain
@@ -217,12 +219,12 @@ module "waf" {
 module "cloudfront" {
   source = "../../modules/cloudfront"
 
-  environment            = var.environment
-  api_gateway_invoke_url = module.api_gateway.api_endpoint
-  waf_web_acl_arn        = module.waf.web_acl_arn
-  custom_domain_name     = var.custom_domain_name
-  certificate_arn        = module.certificate_manager.cloudfront_certificate_arn
-  cloudfront_secret_header = local.cloudfront_secret  
+  environment              = var.environment
+  api_gateway_invoke_url   = module.api_gateway.api_endpoint
+  waf_web_acl_arn          = module.waf.web_acl_arn
+  custom_domain_name       = var.custom_domain_name
+  certificate_arn          = module.certificate_manager.cloudfront_certificate_arn
+  cloudfront_secret_header = local.cloudfront_secret
 
   tags = {
     Environment = var.environment
@@ -233,10 +235,10 @@ module "cloudfront" {
 # Lambda Authorizer for CloudFront secret validation
 module "lambda_authorizer" {
   source = "../../modules/lambda-authorizer"
-  
+
   environment       = var.environment
   cloudfront_secret = local.cloudfront_secret
-  
+
   tags = {
     Environment = var.environment
     Project     = "fields-of-the-world"
@@ -246,9 +248,9 @@ module "lambda_authorizer" {
 # SQS Module - Task queue to replace asyncio.Queue
 module "sqs" {
   source = "../../modules/sqs"
-  
+
   environment = var.environment
-  
+
   tags = {
     Environment = var.environment
     Project     = "fields-of-the-world"

--- a/modules/dynamodb/main.tf
+++ b/modules/dynamodb/main.tf
@@ -7,17 +7,18 @@ terraform {
   }
 }
 
-# DYNAMODB TABLE FOR PROJECT MANAGEMENT
+# DYNAMODB TABLES FOR PROJECT MANAGEMENT
 
-resource "aws_dynamodb_table" "ftw_inference_api_table" {
-  name           = "${var.environment}-ftw-inference-api-table"
+# Projects table - stores project metadata and state
+resource "aws_dynamodb_table" "projects" {
+  name           = "${var.environment}-ftw-projects"
   billing_mode   = "PROVISIONED"
   read_capacity  = var.read_capacity
   write_capacity = var.write_capacity
-  hash_key       = "project_id"
+  hash_key       = "id"
 
   attribute {
-    name = "project_id"
+    name = "id"
     type = "S"
   }
 
@@ -34,9 +35,130 @@ resource "aws_dynamodb_table" "ftw_inference_api_table" {
   tags = merge(
     var.tags,
     {
-      Name        = "${var.environment}-ftw-inference-api-table"
+      Name        = "${var.environment}-ftw-projects"
       Environment = var.environment
       Purpose     = "project-state-management"
+    }
+  )
+}
+
+# Images table - stores image metadata for projects
+resource "aws_dynamodb_table" "images" {
+  name           = "${var.environment}-ftw-images"
+  billing_mode   = "PROVISIONED"
+  read_capacity  = var.read_capacity
+  write_capacity = var.write_capacity
+  hash_key       = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+
+  attribute {
+    name = "project_id"
+    type = "S"
+  }
+
+  attribute {
+    name = "window"
+    type = "S"
+  }
+
+  # GSI for querying by project_id and window
+  global_secondary_index {
+    name            = "project-window-index"
+    hash_key        = "project_id"
+    range_key       = "window"
+    read_capacity   = var.gsi_read_capacity
+    write_capacity  = var.gsi_write_capacity
+    projection_type = "ALL"
+  }
+
+  # Enable point-in-time recovery
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  # Server-side encryption
+  server_side_encryption {
+    enabled = true
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name        = "${var.environment}-ftw-images"
+      Environment = var.environment
+      Purpose     = "image-metadata-storage"
+    }
+  )
+}
+
+# Inference Results table - stores ML inference outputs
+resource "aws_dynamodb_table" "inference_results" {
+  name           = "${var.environment}-ftw-inference-results"
+  billing_mode   = "PROVISIONED"
+  read_capacity  = var.read_capacity
+  write_capacity = var.write_capacity
+  hash_key       = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+
+  attribute {
+    name = "project_id"
+    type = "S"
+  }
+
+  attribute {
+    name = "result_type"
+    type = "S"
+  }
+
+  attribute {
+    name = "created_at"
+    type = "S"
+  }
+
+  # GSI for querying by project_id and result_type
+  global_secondary_index {
+    name            = "project-type-index"
+    hash_key        = "project_id"
+    range_key       = "result_type"
+    read_capacity   = var.gsi_read_capacity
+    write_capacity  = var.gsi_write_capacity
+    projection_type = "ALL"
+  }
+
+  # GSI for querying latest results by created_at
+  global_secondary_index {
+    name            = "project-created-index"
+    hash_key        = "project_id"
+    range_key       = "created_at"
+    read_capacity   = var.gsi_read_capacity
+    write_capacity  = var.gsi_write_capacity
+    projection_type = "ALL"
+  }
+
+  # Enable point-in-time recovery
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  # Server-side encryption
+  server_side_encryption {
+    enabled = true
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name        = "${var.environment}-ftw-inference-results"
+      Environment = var.environment
+      Purpose     = "inference-results-storage"
     }
   )
 }
@@ -49,7 +171,7 @@ resource "aws_vpc_endpoint" "dynamodb" {
   vpc_endpoint_type = "Gateway"
   route_table_ids   = var.route_table_ids
 
-  # Policy to allow access to our specific table
+  # Policy to allow access to all our tables
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -66,8 +188,12 @@ resource "aws_vpc_endpoint" "dynamodb" {
           "dynamodb:DescribeTable"
         ]
         Resource = [
-          aws_dynamodb_table.ftw_inference_api_table.arn,
-          "${aws_dynamodb_table.ftw_inference_api_table.arn}/*"
+          aws_dynamodb_table.projects.arn,
+          "${aws_dynamodb_table.projects.arn}/*",
+          aws_dynamodb_table.images.arn,
+          "${aws_dynamodb_table.images.arn}/*",
+          aws_dynamodb_table.inference_results.arn,
+          "${aws_dynamodb_table.inference_results.arn}/*"
         ]
       }
     ]

--- a/modules/dynamodb/outputs.tf
+++ b/modules/dynamodb/outputs.tf
@@ -1,16 +1,49 @@
-output "dynamodb_table_name" {
-  description = "Name of the DynamoDB table"
-  value       = aws_dynamodb_table.ftw_inference_api_table.name
+# Projects Table Outputs
+output "projects_table_name" {
+  description = "Name of the Projects DynamoDB table"
+  value       = aws_dynamodb_table.projects.name
 }
 
-output "dynamodb_table_arn" {
-  description = "ARN of the DynamoDB table"
-  value       = aws_dynamodb_table.ftw_inference_api_table.arn
+output "projects_table_arn" {
+  description = "ARN of the Projects DynamoDB table"
+  value       = aws_dynamodb_table.projects.arn
 }
 
-output "dynamodb_table_id" {
-  description = "ID of the DynamoDB table"
-  value       = aws_dynamodb_table.ftw_inference_api_table.id
+output "projects_table_id" {
+  description = "ID of the Projects DynamoDB table"
+  value       = aws_dynamodb_table.projects.id
+}
+
+# Images Table Outputs
+output "images_table_name" {
+  description = "Name of the Images DynamoDB table"
+  value       = aws_dynamodb_table.images.name
+}
+
+output "images_table_arn" {
+  description = "ARN of the Images DynamoDB table"
+  value       = aws_dynamodb_table.images.arn
+}
+
+output "images_table_id" {
+  description = "ID of the Images DynamoDB table"
+  value       = aws_dynamodb_table.images.id
+}
+
+# Inference Results Table Outputs
+output "inference_results_table_name" {
+  description = "Name of the Inference Results DynamoDB table"
+  value       = aws_dynamodb_table.inference_results.name
+}
+
+output "inference_results_table_arn" {
+  description = "ARN of the Inference Results DynamoDB table"
+  value       = aws_dynamodb_table.inference_results.arn
+}
+
+output "inference_results_table_id" {
+  description = "ID of the Inference Results DynamoDB table"
+  value       = aws_dynamodb_table.inference_results.id
 }
 
 output "vpc_endpoint_id" {

--- a/modules/dynamodb/variables.tf
+++ b/modules/dynamodb/variables.tf
@@ -30,6 +30,18 @@ variable "write_capacity" {
   default     = 5
 }
 
+variable "gsi_read_capacity" {
+  description = "Read capacity units for Global Secondary Indexes"
+  type        = number
+  default     = 5
+}
+
+variable "gsi_write_capacity" {
+  description = "Write capacity units for Global Secondary Indexes"
+  type        = number
+  default     = 5
+}
+
 variable "tags" {
   description = "Tags to apply to DynamoDB resources"
   type        = map(string)

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -134,8 +134,12 @@ resource "aws_iam_role_policy" "ec2_dynamodb_policy" {
           "dynamodb:DescribeTable"
         ]
         Resource = [
-          var.dynamodb_table_arn,
-          "${var.dynamodb_table_arn}/*"
+          var.projects_table_arn,
+          "${var.projects_table_arn}/*",
+          var.images_table_arn,
+          "${var.images_table_arn}/*",
+          var.inference_results_table_arn,
+          "${var.inference_results_table_arn}/*"
         ]
       }
     ]
@@ -194,7 +198,7 @@ resource "aws_iam_role_policy" "api_gateway_cloudwatch_policy" {
 
 # SQS access policy for EC2 (only create if SQS ARN is provided)
 resource "aws_iam_role_policy" "ec2_sqs_policy" {
-  
+
   name = "${var.environment}-ec2-sqs-policy"
   role = aws_iam_role.ec2_fastapi_app_role.id
 

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -25,8 +25,18 @@ variable "enable_alb_oidc_auth" {
   default     = false
 }
 
-variable "dynamodb_table_arn" {
-  description = "DynamoDB table ARN for EC2 access"
+variable "projects_table_arn" {
+  description = "Projects DynamoDB table ARN for EC2 access"
+  type        = string
+}
+
+variable "images_table_arn" {
+  description = "Images DynamoDB table ARN for EC2 access"
+  type        = string
+}
+
+variable "inference_results_table_arn" {
+  description = "Inference Results DynamoDB table ARN for EC2 access"
   type        = string
 }
 variable "sqs_queue_arn" {


### PR DESCRIPTION
Replaced single DynamoDB table with three specialized tables to support new data model architecture.

Changes

- DynamoDB: Replace dev-ftw-inference-api-table with three tables:
	- `dev-ftw-projects` - Project metadata and state management
	- `dev-ftw-images` - Image metadata with GSI for project+window queries
	- `dev-ftw-inference-results` - ML inference outputs with GSIs for project+type and project+created_at queries
- IAM: Update EC2 policies to grant access to all three tables
- VPC: Update DynamoDB endpoint policy to include all three tables

Complete tests

- Terraform apply successful - infrastructure deployed
- Successfully tested new dynamodb flow with `ftw-inference-api`