### PR TITLE
Add Embeddings EC2 Instance

### DIFF
--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -113,8 +113,8 @@ module "iam" {
   sqs_dlq_arn                 = module.sqs.dlq_arn
 
   # External role configuration for cross-account access
-  external_role_arn            = var.external_role_arn
-  external_role_id             = var.external_role_id
+  external_role_arn = var.external_role_arn
+  external_role_id  = var.external_role_id
 }
 
 module "api_gateway" {
@@ -205,9 +205,9 @@ module "ec2" {
   asg_config    = var.asg_config
 
   # Embeddings instance - just enable/disable, all config is in module
-  enable_embeddings_instance     = var.enable_embeddings_instance
-  public_subnet_id               = module.vpc.public_subnet_ids[0]
-  embeddings_security_group_ids  = var.enable_embeddings_instance ? [module.security_groups.embeddings_ssh_security_group_id] : []
+  enable_embeddings_instance    = var.enable_embeddings_instance
+  public_subnet_id              = module.vpc.public_subnet_ids[0]
+  embeddings_security_group_ids = var.enable_embeddings_instance ? [module.security_groups.embeddings_ssh_security_group_id] : []
 }
 # WAF Module - Web Application Firewall for CloudFront
 module "waf" {

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -168,6 +168,7 @@ module "security_groups" {
   vpc_id                  = module.vpc.vpc_id
   vpc_cidr_block          = module.vpc.vpc_cidr_block
   enable_vpc_endpoints_sg = true
+  enable_embeddings_sg    = var.enable_embeddings_instance
 }
 
 module "alb" {
@@ -202,6 +203,11 @@ module "ec2" {
   instance_type = var.instance_type
   key_pair_name = var.key_pair_name
   asg_config    = var.asg_config
+
+  # Embeddings instance - just enable/disable, all config is in module
+  enable_embeddings_instance     = var.enable_embeddings_instance
+  public_subnet_id               = module.vpc.public_subnet_ids[0]
+  embeddings_security_group_ids  = var.enable_embeddings_instance ? [module.security_groups.embeddings_ssh_security_group_id] : []
 }
 # WAF Module - Web Application Firewall for CloudFront
 module "waf" {

--- a/environments/dev/outputs.tf
+++ b/environments/dev/outputs.tf
@@ -37,3 +37,40 @@ output "ami_id" {
   description = "The AMI ID used by the EC2 instances"
   value       = module.ec2.ami_id
 }
+
+# Embeddings Instance Outputs
+output "embeddings_instance_id" {
+  description = "ID of the embeddings EC2 instance"
+  value       = module.ec2.embeddings_instance_id
+}
+
+output "embeddings_elastic_ip" {
+  description = "Elastic IP address of the embeddings instance"
+  value       = module.ec2.embeddings_elastic_ip
+}
+
+output "embeddings_ssh_connection" {
+  description = "SSH connection command for the embeddings instance"
+  value       = module.ec2.embeddings_ssh_connection
+}
+
+output "embeddings_instance_status" {
+  description = "Status information for embeddings instance"
+  value = var.enable_embeddings_instance ? {
+    enabled     = true
+    instance_id = module.ec2.embeddings_instance_id
+    public_ip   = module.ec2.embeddings_elastic_ip
+    private_ip  = module.ec2.embeddings_instance_private_ip
+    key_name    = module.ec2.embeddings_key_name
+  } : {
+    enabled = false
+    message = "Embeddings instance is not enabled. Set enable_embeddings_instance = true to create it."
+  }
+}
+
+# Sensitive output for private key
+output "embeddings_private_key" {
+  description = "Private SSH key for embeddings instance (only if auto-generated - save this securely!)"
+  value       = module.ec2.embeddings_private_key_pem
+  sensitive   = true
+}

--- a/environments/dev/outputs.tf
+++ b/environments/dev/outputs.tf
@@ -62,7 +62,7 @@ output "embeddings_instance_status" {
     public_ip   = module.ec2.embeddings_elastic_ip
     private_ip  = module.ec2.embeddings_instance_private_ip
     key_name    = module.ec2.embeddings_key_name
-  } : {
+    } : {
     enabled = false
     message = "Embeddings instance is not enabled. Set enable_embeddings_instance = true to create it."
   }

--- a/environments/dev/terraform.tfvars.example
+++ b/environments/dev/terraform.tfvars.example
@@ -41,9 +41,13 @@ asg_config = {
 # Cross-account S3 Access Configuration
 # If you need EC2 instances to assume an external role to access S3 buckets in other AWS accounts,
 # provide the role ARN and optional external ID below
-external_role_arn = ""
-external_role_id  = ""
+external_role_arn = "arn:aws:iam::417712557820:role/ftw-cross-account-access"
+external_role_id  = "tge"
 
 # Example for accessing external S3 buckets via STS AssumeRole:
 # external_role_arn = "arn:aws:iam::123456789012:role/cross-account-s3-access-role"
 # external_role_id  = "unique-external-id-for-security"
+
+# Embedding EC2 instance
+# To enable the embeddings EC2 instance (t3.2xlarge with 80GB storage):
+# enable_embeddings_instance = true

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -207,3 +207,10 @@ variable "external_role_id" {
   type        = string
   default     = ""
 }
+
+# Single control variable for embeddings instance
+variable "enable_embeddings_instance" {
+  description = "Whether to create the embeddings EC2 instance"
+  type        = bool
+  default     = false
+}

--- a/modules/api-gateway/main.tf
+++ b/modules/api-gateway/main.tf
@@ -116,20 +116,20 @@ resource "aws_apigatewayv2_vpc_link" "main" {
 
 # Lambda authorizer for CloudFront secret validation
 resource "aws_apigatewayv2_authorizer" "cloudfront_authorizer" {
-  api_id           = aws_apigatewayv2_api.main.id
-  authorizer_type  = "REQUEST"
-  authorizer_uri   = var.lambda_authorizer_invoke_arn
-  name             = "${var.environment}-cloudfront-authorizer"
-  
+  api_id          = aws_apigatewayv2_api.main.id
+  authorizer_type = "REQUEST"
+  authorizer_uri  = var.lambda_authorizer_invoke_arn
+  name            = "${var.environment}-cloudfront-authorizer"
+
   # Pass all headers to authorizer
   authorizer_payload_format_version = "2.0"
-  
+
   # Enable simple responses for format 2.0 (allows {"isAuthorized": true/false})
   enable_simple_responses = true
-  
+
   # Cache authorization for 5 minutes
   authorizer_result_ttl_in_seconds = 300
-  
+
   # Required for Lambda authorizers
   identity_sources = ["$request.header.x-cloudfront-secret"]
 }

--- a/modules/api-gateway/routes.tf
+++ b/modules/api-gateway/routes.tf
@@ -27,9 +27,9 @@ resource "aws_apigatewayv2_route" "api_routes" {
   api_id    = aws_apigatewayv2_api.main.id
   route_key = each.value.route_key
   target    = "integrations/${aws_apigatewayv2_integration.alb_integration.id}"
-  
+
   # Authorization logic - same for all routes, defined once
   authorization_type = var.enable_cloudfront_protection ? "CUSTOM" : "NONE"
-  authorizer_id     = var.enable_cloudfront_protection ? aws_apigatewayv2_authorizer.cloudfront_authorizer.id : null
+  authorizer_id      = var.enable_cloudfront_protection ? aws_apigatewayv2_authorizer.cloudfront_authorizer.id : null
 }
 

--- a/modules/api-gateway/variables.tf
+++ b/modules/api-gateway/variables.tf
@@ -74,9 +74,9 @@ variable "api_routes" {
   description = "Map of API routes to create"
   type = map(object({
     route_key = string
-   # methods   = list(string)
+    # methods   = list(string)
   }))
-  
+
   default = {
     "root"                  = { route_key = "GET /", methods = ["GET"] }
     "example"               = { route_key = "PUT /example", methods = ["PUT"] }

--- a/modules/api-gateway/variables.tf
+++ b/modules/api-gateway/variables.tf
@@ -89,5 +89,7 @@ variable "api_routes" {
     "inference"             = { route_key = "PUT /projects/{project_id}/inference", methods = ["PUT"] }
     "polygonization"        = { route_key = "PUT /projects/{project_id}/polygons", methods = ["PUT"] }
     "get_task_status"       = { route_key = "GET /projects/{project_id}/tasks/{task_id}", methods = ["GET"] }
+    "get_inference_results" = { route_key = "GET /projects/{project_id}/inference", methods = ["GET"] }
+    "scene_selection"       = { route_key = "POST /scene-selection", methods = ["POST"] }
   }
 }

--- a/modules/certificate-manager/outputs.tf
+++ b/modules/certificate-manager/outputs.tf
@@ -31,5 +31,5 @@ output "cloudfront_certificate_arn" {
 output "route53_name_servers" {
   description = "Route53 name servers for the hosted zone (empty if no custom domain)"
 
-  value       = var.ssl_config.custom_domain_name != "" ? aws_route53_zone.main[0].name_servers : []
+  value = var.ssl_config.custom_domain_name != "" ? aws_route53_zone.main[0].name_servers : []
 }

--- a/modules/cloudfront/main.tf
+++ b/modules/cloudfront/main.tf
@@ -64,9 +64,9 @@ resource "aws_cloudfront_distribution" "api_distribution" {
     allowed_methods            = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods             = ["GET", "HEAD"]
     compress                   = true
-    cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-    origin_request_policy_id   = data.aws_cloudfront_origin_request_policy.all_viewer_except_host.id
-    response_headers_policy_id = data.aws_cloudfront_response_headers_policy.simple_cors.id
+    cache_policy_id            = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"  # Managed-CachingDisabled
+    origin_request_policy_id   = "b689b0a8-53d0-40ab-baf2-68738e2966ac"  # Managed-AllViewerExceptHostHeader
+    response_headers_policy_id = "60669652-455b-4ae9-85a4-c4c02393f86c"  # Managed-SimpleCORS
   }
 
   # Geographic restrictions (none for now)

--- a/modules/cloudfront/main.tf
+++ b/modules/cloudfront/main.tf
@@ -39,11 +39,11 @@ resource "aws_cloudfront_distribution" "api_distribution" {
     domain_name = regex("https://([^/]+)", var.api_gateway_invoke_url)[0]
     origin_id   = "api-gateway-${var.environment}"
 
-# Points to the API Gateway 
+    # Points to the API Gateway 
     custom_header {
-    name  = "X-CloudFront-Secret"
-    value = var.cloudfront_secret_header
-  }
+      name  = "X-CloudFront-Secret"
+      value = var.cloudfront_secret_header
+    }
 
     custom_origin_config {
       http_port              = 80
@@ -64,9 +64,9 @@ resource "aws_cloudfront_distribution" "api_distribution" {
     allowed_methods            = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods             = ["GET", "HEAD"]
     compress                   = true
-    cache_policy_id            = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"  # Managed-CachingDisabled
-    origin_request_policy_id   = "b689b0a8-53d0-40ab-baf2-68738e2966ac"  # Managed-AllViewerExceptHostHeader
-    response_headers_policy_id = "60669652-455b-4ae9-85a4-c4c02393f86c"  # Managed-SimpleCORS
+    cache_policy_id            = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # Managed-CachingDisabled
+    origin_request_policy_id   = "b689b0a8-53d0-40ab-baf2-68738e2966ac" # Managed-AllViewerExceptHostHeader
+    response_headers_policy_id = "60669652-455b-4ae9-85a4-c4c02393f86c" # Managed-SimpleCORS
   }
 
   # Geographic restrictions (none for now)

--- a/modules/ec2/outputs.tf
+++ b/modules/ec2/outputs.tf
@@ -62,3 +62,54 @@ output "asg_configuration" {
     health_check_grace_period = var.asg_config.health_check_grace_period
   }
 }
+
+################################################################################
+# EMBEDDINGS INSTANCE OUTPUTS
+################################################################################
+
+output "embeddings_instance_id" {
+  description = "ID of the embeddings EC2 instance"
+  value       = var.enable_embeddings_instance ? aws_instance.embeddings[0].id : null
+}
+
+output "embeddings_instance_public_ip" {
+  description = "Public IP address of the embeddings instance"
+  value       = var.enable_embeddings_instance ? aws_instance.embeddings[0].public_ip : null
+}
+
+output "embeddings_elastic_ip" {
+  description = "Elastic IP address of the embeddings instance"
+  value       = var.enable_embeddings_instance ? aws_eip.embeddings_eip[0].public_ip : null
+}
+
+output "embeddings_instance_private_ip" {
+  description = "Private IP address of the embeddings instance"
+  value       = var.enable_embeddings_instance ? aws_instance.embeddings[0].private_ip : null
+}
+
+output "embeddings_key_name" {
+  description = "Name of the SSH key pair for embeddings instance"
+  value       = var.enable_embeddings_instance ? aws_key_pair.embeddings_key[0].key_name : null
+}
+
+output "embeddings_instance_arn" {
+  description = "ARN of the embeddings EC2 instance"
+  value       = var.enable_embeddings_instance ? aws_instance.embeddings[0].arn : null
+}
+
+output "embeddings_ssh_connection" {
+  description = "SSH connection string for the embeddings instance"
+  value       = var.enable_embeddings_instance ? "ssh -i ~/.ssh/${var.environment}-embeddings-key.pem ubuntu@${aws_eip.embeddings_eip[0].public_ip}" : null
+}
+
+output "embeddings_private_key_pem" {
+  description = "Private key for SSH access (only if auto-generated)"
+  value       = var.enable_embeddings_instance && var.embeddings_public_key == "" ? tls_private_key.embeddings_key[0].private_key_pem : null
+  sensitive   = true
+}
+
+output "embeddings_private_key_openssh" {
+  description = "Private key in OpenSSH format (only if auto-generated)"
+  value       = var.enable_embeddings_instance && var.embeddings_public_key == "" ? tls_private_key.embeddings_key[0].private_key_openssh : null
+  sensitive   = true
+}

--- a/modules/ec2/variables.tf
+++ b/modules/ec2/variables.tf
@@ -75,3 +75,53 @@ variable "fastapi_app_port" {
   type        = number
   default     = 8000
 }
+
+################################################################################
+# EMBEDDINGS INSTANCE VARIABLES
+################################################################################
+
+variable "enable_embeddings_instance" {
+  description = "Whether to create the embeddings EC2 instance"
+  type        = bool
+  default     = false
+}
+
+variable "embeddings_instance_type" {
+  description = "EC2 instance type for embeddings server (internal default)"
+  type        = string
+  default     = "t3.2xlarge"
+
+  validation {
+    condition     = can(regex("^[a-z][0-9][a-z]*\\.[0-9]*[a-z]+$", var.embeddings_instance_type))
+    error_message = "Instance type must be a valid AWS instance type format."
+  }
+}
+
+variable "embeddings_volume_size" {
+  description = "EBS volume size in GB for embeddings instance (internal default)"
+  type        = number
+  default     = 80
+
+  validation {
+    condition     = var.embeddings_volume_size >= 8 && var.embeddings_volume_size <= 16384
+    error_message = "Volume size must be between 8 and 16384 GB."
+  }
+}
+
+variable "public_subnet_id" {
+  description = "Public subnet ID for embeddings instance (passed from vpc module)"
+  type        = string
+  default     = ""
+}
+
+variable "embeddings_security_group_ids" {
+  description = "Security group IDs for embeddings instance (passed from security-groups module)"
+  type        = list(string)
+  default     = []
+}
+
+variable "embeddings_public_key" {
+  description = "SSH public key for embeddings instance (leave empty for auto-generation)"
+  type        = string
+  default     = ""
+}

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -94,8 +94,8 @@ resource "aws_iam_role_policy" "ec2_assume_external_role" {
     Version = "2012-10-17"
     Statement = [
       {
-        Effect = "Allow"
-        Action = "sts:AssumeRole"
+        Effect   = "Allow"
+        Action   = "sts:AssumeRole"
         Resource = var.external_role_arn
         Condition = var.external_role_id != "" ? {
           StringEquals = {

--- a/modules/lambda-authorizer/main.tf
+++ b/modules/lambda-authorizer/main.tf
@@ -52,12 +52,12 @@ resource "aws_iam_role_policy_attachment" "authorizer_basic" {
 
 # Lambda function for CloudFront secret validation
 resource "aws_lambda_function" "cloudfront_authorizer" {
-  filename         = data.archive_file.authorizer_zip.output_path
-  function_name    = "${var.environment}-cloudfront-authorizer"
-  role            = aws_iam_role.authorizer_role.arn
-  handler         = "index.lambda_handler"
-  runtime         = "python3.13"
-  timeout         = 30
+  filename      = data.archive_file.authorizer_zip.output_path
+  function_name = "${var.environment}-cloudfront-authorizer"
+  role          = aws_iam_role.authorizer_role.arn
+  handler       = "index.lambda_handler"
+  runtime       = "python3.13"
+  timeout       = 30
 
   source_code_hash = data.archive_file.authorizer_zip.output_base64sha256
 

--- a/modules/security-groups/main.tf
+++ b/modules/security-groups/main.tf
@@ -179,3 +179,43 @@ resource "aws_security_group" "vpc_endpoints" {
     create_before_destroy = true
   }
 }
+
+################################################################################
+# Security Group for Embeddings Instance (SSH Access)
+################################################################################
+resource "aws_security_group" "embeddings_ssh" {
+  count       = var.enable_embeddings_sg ? 1 : 0
+  name_prefix = "${var.environment}-embeddings-ssh-sg"
+  description = "Security group for embeddings instance with SSH access from internet"
+  vpc_id      = var.vpc_id
+
+  # SSH inbound from internet
+  ingress {
+    description      = "SSH from internet"
+    from_port        = 22
+    to_port          = 22
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  # All outbound traffic
+  egress {
+    description      = "All outbound traffic"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  tags = {
+    Name        = "${var.environment}-embeddings-ssh-sg"
+    Environment = var.environment
+    Purpose     = "embeddings-instance-ssh"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/modules/security-groups/outputs.tf
+++ b/modules/security-groups/outputs.tf
@@ -46,3 +46,14 @@ output "fastapi_app_port" {
   description = "The port configured for the FastAPI application"
   value       = var.fastapi_app_port
 }
+
+# Embeddings Instance Security Group outputs (conditional)
+output "embeddings_ssh_security_group_id" {
+  description = "The ID of the embeddings SSH security group"
+  value       = var.enable_embeddings_sg ? aws_security_group.embeddings_ssh[0].id : null
+}
+
+output "embeddings_ssh_security_group_arn" {
+  description = "The ARN of the embeddings SSH security group"
+  value       = var.enable_embeddings_sg ? aws_security_group.embeddings_ssh[0].arn : null
+}

--- a/modules/security-groups/variables.tf
+++ b/modules/security-groups/variables.tf
@@ -29,3 +29,9 @@ variable "enable_vpc_endpoints_sg" {
   type        = bool
   default     = true
 }
+
+variable "enable_embeddings_sg" {
+  description = "Create security group for embeddings instance"
+  type        = bool
+  default     = false
+}

--- a/modules/security-groups/variables.tf
+++ b/modules/security-groups/variables.tf
@@ -19,7 +19,7 @@ variable "fastapi_app_port" {
   default     = 8000
 
   validation {
-    condition = var.fastapi_app_port >= 1024 && var.fastapi_app_port <= 65535
+    condition     = var.fastapi_app_port >= 1024 && var.fastapi_app_port <= 65535
     error_message = "FastAPI port must be between 1024 and 65535."
   }
 }

--- a/modules/sqs/main.tf
+++ b/modules/sqs/main.tf
@@ -30,7 +30,7 @@ resource "aws_sqs_queue" "task_queue" {
   # Message settings for ML tasks
   visibility_timeout_seconds = var.visibility_timeout
   message_retention_seconds  = var.message_retention_period
-  
+
   # Long polling for efficiency
   receive_wait_time_seconds = 20
 
@@ -58,11 +58,11 @@ resource "aws_sqs_queue_policy" "task_queue_policy" {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "DenyInsecureTaskQueue"
-        Effect = "Deny"
-        Principal = "*" 
-        Action = "sqs:*"
-        Resource = aws_sqs_queue.task_queue.arn
+        Sid       = "DenyInsecureTaskQueue"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "sqs:*"
+        Resource  = aws_sqs_queue.task_queue.arn
         Condition = {
           Bool = {
             "aws:SecureTransport" = "false"
@@ -70,11 +70,11 @@ resource "aws_sqs_queue_policy" "task_queue_policy" {
         }
       },
       {
-        Sid    = "DenyInsecureDLQ"
-        Effect = "Deny"
-        Principal = "*" 
-        Action = "sqs:*"
-        Resource = aws_sqs_queue.task_dlq.arn
+        Sid       = "DenyInsecureDLQ"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "sqs:*"
+        Resource  = aws_sqs_queue.task_dlq.arn
         Condition = {
           Bool = {
             "aws:SecureTransport" = "false"

--- a/modules/sqs/variables.tf
+++ b/modules/sqs/variables.tf
@@ -6,13 +6,13 @@ variable "environment" {
 variable "visibility_timeout" {
   description = "Message visibility timeout in seconds (for long-running ML tasks)"
   type        = number
-  default     = 900  # 15 minutes for inference/polygonize tasks
+  default     = 900 # 15 minutes for inference/polygonize tasks
 }
 
 variable "message_retention_period" {
   description = "How long to keep messages in queue (seconds)"
   type        = number
-  default     = 1209600  # 14 days
+  default     = 1209600 # 14 days
 }
 
 variable "max_receive_count" {


### PR DESCRIPTION
## Summary
Adds a new standalone EC2 instance for running embeddings models with full S3 access to the FTW model outputs bucket.

## Changes

### Infrastructure Components Added
- **EC2 Instance**: t3.2xlarge Ubuntu 22.04 LTS instance in public subnet
- **Elastic IP**: Static public IP address for persistent access
- **Security Group**: SSH access (port 22) from internet
- **SSH Key Pair**: Auto-generated RSA 4096-bit key using TLS provider
- **IAM Access**: Uses existing EC2 FastAPI instance profile with full S3 permissions

### Configuration
- Instance Type: `t3.2xlarge` (8 vCPUs, 32 GB RAM)
- Storage: 80 GB GP3 EBS volume (encrypted)
- OS: Ubuntu 22.04 LTS (latest)
- Access: SSH via auto-generated key + AWS SSM Session Manager
- Network: Public subnet with Elastic IP

### Module Changes
- **modules/ec2**: Added embeddings instance resources with auto-generated SSH keys
- **modules/security-groups**: Added SSH security group for embeddings instance
- **environments/dev**: Added single control flag `enable_embeddings_instance`

### Key Features
- Auto-generated SSH key pair (no manual key management required)
- Full S3 read/write/delete access to FTW model outputs bucket via IAM role
- All configuration defaults are contained in the EC2 module
- Simple enable/disable via single environment variable
- Sensitive outputs for private key retrieval

## Additional Changes
- Terraform formatting applied across all modules